### PR TITLE
Fixed #57

### DIFF
--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -38,4 +38,8 @@ server {
     location ~ /\.ht {
         deny all;
     }
+
+    location ~ /\.git {
+        deny all;
+    }
 }


### PR DESCRIPTION
Currently nginx exposing the. git directory to the public [Issue #57 ] which leaks the private repository access to the public 
to fix that I have added a rule to deny all access requests to .git directory in default config.